### PR TITLE
Add disk reading functionality.

### DIFF
--- a/windows-imager.zig
+++ b/windows-imager.zig
@@ -312,6 +312,7 @@ pub fn main2() anyerror!u8 {
             \\Usage: windows-imager COMMAND ARGS...
             \\  list              list physical disks
             \\  image DRIVE FILE  image the given drive with the given file
+            \\  read DRIVE FILE   read the given drive to the given file
             \\  listvolumes       list volume paths (i.e. \\?\Volume{{6abe...}}\)
             \\  listlogicaldrives list logical drives (i.e. C:\)
             , .{});
@@ -403,6 +404,68 @@ pub fn main2() anyerror!u8 {
         return 0;
     }
 
+    if (mem.eql(u8, cmd, "read")) {
+        try enforceArgCount(args, 2);
+        const drive = try std.unicode.utf8ToUtf16LeWithNull(allocator, args[0]);
+        //const fileSlice = args[1];
+        //const file = try allocator.allocSentinel(u8, fileSlice.len, 0);
+        //mem.copy(u8, file, fileSlice);
+        const file = try std.unicode.utf8ToUtf16LeWithNull(allocator, args[1]);
+
+        const disk_handle = openDisk(drive, win.GENERIC_READ | win.GENERIC_WRITE) catch |e| {
+            std.debug.print("Error: Failed to open drive \"{}\" {}\n", .{formatU16(drive), e});
+            return error.AlreadyReported;
+        };
+        const disk_geo = try getDiskGeo(disk_handle);
+        printDiskSummary(null, drive, disk_geo);
+
+        const disk_size = sumDiskSize(disk_geo);
+        // const file_size = try win.GetFileSizeEx(file_handle);
+        {
+            var typedDiskSize : f32 = @intToFloat(f32, disk_size);
+            var suffix : []const u8 = undefined;
+            getNiceSize(&typedDiskSize, &suffix);
+            std.debug.print("disk size is {} ({d:.2} {s})\n", .{disk_size, typedDiskSize, suffix});
+        }
+
+        // if (file_size > disk_size) {
+        //     std.debug.print("Error: file is too big\n", .{});
+        //     return error.AlreadyReported;
+        // }
+
+        if (!try promptYesNo(allocator, "Are you sure you would like to read this drive? ")) {
+            return 1;
+        }
+
+        // Do the prompt before overwriting the output file.
+        const file_handle = kernel32.CreateFileW(
+            file,
+            win.GENERIC_WRITE,
+            win.FILE_SHARE_READ | win.FILE_SHARE_WRITE,
+            null,
+            win.CREATE_ALWAYS,
+            win.FILE_ATTRIBUTE_NORMAL,
+            null
+        );
+        if (file_handle == win.INVALID_HANDLE_VALUE) {
+           // FIXME: {any} should be {s} when zig supports u16.
+           std.debug.print("Error: failed to open '{any}', error={}\n", .{file, kernel32.GetLastError()});
+           return error.AlreadyReported;
+        }
+
+        // TODO: what is a good transfer size? Do some perf testing
+        //const transfer_size = disk_geo.BytesPerSector;
+        const transfer_size = 1024 * 1024;
+        {
+            // TODO: should this allocation be aligned?  Do some perf testing to see if it helps
+            const buf = try allocator.alloc(u8, transfer_size);
+            defer allocator.free(buf);
+            try readDisk(disk_handle, file_handle, disk_size, buf);
+        }
+        std.debug.print("Successfully read drive\n", .{});
+        return 0;
+    }
+
     std.debug.print("Error: unknown command '{s}'\n", .{cmd});
     return 1;
 }
@@ -435,6 +498,52 @@ fn imageDisk(disk_handle: win.HANDLE, file_handle: win.HANDLE, file_size: u64, b
             var written : u32 = undefined;
             if (0 == kernel32.WriteFile(disk_handle, buf.ptr, @intCast(u32, size), &written, null)) {
                 std.debug.print("Error: WriteFile to drive (size={}, total_written={}) failed, error={}\n",.{
+                    size, total_processed, kernel32.GetLastError()});
+                return error.AlreadyReported;
+            }
+            std.debug.assert(written == size);
+        }
+
+        total_processed += size;
+        //std.debug.print("[DEBUG] write {} bytes (total={})\n", .{size, total_processed});
+        const now = GetTickCount();
+        // TODO: allow rollover
+        if ((now - last_report_ticks) > report_frequency) {
+            const progress = @intToFloat(f32, total_processed) / @intToFloat(f32, file_size) * 100;
+            std.debug.print("{d:.0}% ({} bytes)\n", .{progress, total_processed});
+            last_report_ticks = now;
+        }
+    }
+}
+
+fn readDisk(disk_handle: win.HANDLE, file_handle: win.HANDLE, file_size: u64, buf: []u8) !void {
+    std.debug.print("dismounting disk...\n", .{});
+    try dismountDisk(disk_handle);
+    std.debug.print("locking disk...\n", .{});
+    try lockDisk(disk_handle);
+    std.debug.print("disk ready to read\n", .{});
+
+    // do I need to do this?
+    //try win.SetFilePointerEx_BEGIN(disk_handle, 0);
+
+    var total_processed : u64 = 0;
+    var last_report_ticks = GetTickCount();
+    const report_frequency = 1000; // report every 1000 ms
+
+    while (total_processed < file_size) {
+        const size = try win.ReadFile(disk_handle, buf, null, .blocking);
+        std.debug.assert(size > 0);
+        //std.debug.print("[DEBUG] read {} bytes\n", .{size});
+
+        //try win.SetFilePointerEx_BEGIN(disk_handle, total_processed);
+
+        // TODO: if this is the last read, need to pad with zeros
+        //const written = try win.WriteFile(disk_handle, buf[0..size], null, .blocking);
+        //std.debug.assert(written == size);
+        {
+            var written : u32 = undefined;
+            if (0 == kernel32.WriteFile(file_handle, buf.ptr, @intCast(u32, size), &written, null)) {
+                std.debug.print("Error: WriteFile to file (size={}, total_written={}) failed, error={}\n",.{
                     size, total_processed, kernel32.GetLastError()});
                 return error.AlreadyReported;
             }


### PR DESCRIPTION
I don't expect this to be merged as-is, but... at least on my end, it _does_ work for imaging floppy disks, and I imagine it'll work for SD cards and USB sticks as well.

One weakness is that this'll read the entire disk, so images will only survive a round trip unmodified (i.e. without dead space at the end) if they are the exact size of the disk. I can look into adding this, but I'm not sure if the Windows API provides access to the used amount of disk space like that.